### PR TITLE
fix: github actions deployment to use the docs folder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
-
-name: Deploy Site
+name: Deploy Docusaurus Site
 
 on:
   push:
@@ -17,16 +16,20 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '16'
 
     - name: Install dependencies
-      run: yarn
+      run: |
+        cd docs # Navigate to the correct directory if `package.json` is in `docs`
+        yarn
 
     - name: Build site
-      run: yarn build
+      run: |
+        cd docs # Ensure we're in the correct directory
+        yarn build
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./build
+        publish_dir: docs/build # Update the path to the correct `build` directory

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,17 +19,15 @@ jobs:
         node-version: '18'
 
     - name: Install dependencies
-      run: |
-        cd docs # Navigate to the correct directory if `package.json` is in `docs`
-        yarn
+      working-directory: docs
+      run: yarn
 
     - name: Build site
-      run: |
-        cd docs # Ensure we're in the correct directory
-        yarn build
+      working-directory: docs
+      run: yarn build
 
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build # Update the path to the correct `build` directory

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow name to "Deploy Docusaurus Site"
	- Modified Node.js version from 18 to 16
	- Adjusted deployment configuration to target `docs` directory and updated publish path to `docs/build`
	- Updated action version for deployment from v3 to v4
<!-- end of auto-generated comment: release notes by coderabbit.ai -->